### PR TITLE
BingTiles download error fixed. 

### DIFF
--- a/gettilesfrombing.py
+++ b/gettilesfrombing.py
@@ -12,7 +12,6 @@ import imagestoosm.secrets as secrets
 from random import random
 from time import sleep
 
-#secret = "AoxxDlszQe-XFNd6IwlrrjxrtI3Ow-nDn84RIJ5as5HyGvJzERJuA2eiG22GHElt"
 # MS doesn't want you hardcoding the URLs to the tile server. This request asks for the Aerial
 # url template. Replace {quadkey}, and {subdomain}
 response = requests.get("https://dev.virtualearth.net/REST/V1/Imagery/Metadata/Aerial?key=%s" % (secrets.bingKey))
@@ -38,11 +37,9 @@ for classDir in os.listdir(cfg.rootOsmDir) :
             fullPath = os.path.join( cfg.rootOsmDir,classDir,fileName)
             with open(fullPath, "rt") as csvfile:
                 csveader = csv.reader(csvfile, delimiter='\t')
-                print("%s " % (fullPath),end='')
 
                 neededTile = False
                 for row in csveader:
-                    print(row)
                     tilePixel = quadkey.TileSystem.geo_to_pixel((float(row[0]),float(row[1])), cfg.tileZoom)
 
                     for x in range(-2,3) :

--- a/gettilesfrombing.py
+++ b/gettilesfrombing.py
@@ -12,6 +12,7 @@ import imagestoosm.secrets as secrets
 from random import random
 from time import sleep
 
+#secret = "AoxxDlszQe-XFNd6IwlrrjxrtI3Ow-nDn84RIJ5as5HyGvJzERJuA2eiG22GHElt"
 # MS doesn't want you hardcoding the URLs to the tile server. This request asks for the Aerial
 # url template. Replace {quadkey}, and {subdomain}
 response = requests.get("https://dev.virtualearth.net/REST/V1/Imagery/Metadata/Aerial?key=%s" % (secrets.bingKey))
@@ -33,51 +34,50 @@ if ( os.path.exists(bingTilesDir) == False) :
 for classDir in os.listdir(cfg.rootOsmDir) :
     classDirFull = os.path.join( cfg.rootOsmDir,classDir)
     for fileName in os.listdir(classDirFull) :
-        fullPath = os.path.join( cfg.rootOsmDir,classDir,fileName)
-        with open(fullPath, "rt") as csvfile:
-            csveader = csv.reader(csvfile, delimiter='\t')
-            print("%s " % (fullPath),end='')
+        if fileName.endswith(".csv"):
+            fullPath = os.path.join( cfg.rootOsmDir,classDir,fileName)
+            with open(fullPath, "rt") as csvfile:
+                csveader = csv.reader(csvfile, delimiter='\t')
+                print("%s " % (fullPath),end='')
 
-            neededTile = False
-            for row in csveader:
+                neededTile = False
+                for row in csveader:
+                    print(row)
+                    tilePixel = quadkey.TileSystem.geo_to_pixel((float(row[0]),float(row[1])), cfg.tileZoom)
 
-                tilePixel = quadkey.TileSystem.geo_to_pixel((float(row[0]),float(row[1])), cfg.tileZoom)
+                    for x in range(-2,3) :
+                        for y in range(-2,3) :
+                            pixel = ( tilePixel[0] + 256*x, tilePixel[1]+256*y)
+                            geo = quadkey.TileSystem.pixel_to_geo(pixel, cfg.tileZoom)
+                            qk = quadkey.from_geo(geo,cfg.tileZoom)
 
-                for x in range(-2,3) :
-                    for y in range(-2,3) :
-                        pixel = ( tilePixel[0] + 256*x, tilePixel[1]+256*y)
-                        geo = quadkey.TileSystem.pixel_to_geo(pixel, cfg.tileZoom)
-                        qk = quadkey.from_geo(geo,cfg.tileZoom)
+                            qkStr = str(qk)
 
-                        qkStr = str(qk)
+                            tileCacheDir = os.path.join(bingTilesDir,qkStr[-3:])
+                        
+                            if ( os.path.exists(tileCacheDir) == False) :
+                                os.mkdir( tileCacheDir)
 
-                        tileCacheDir = os.path.join(bingTilesDir,qkStr[-3:])
-                    
-                        if ( os.path.exists(tileCacheDir) == False) :
-                            os.mkdir( tileCacheDir)
+                            tileFileName = "%s/%s.jpg" % (tileCacheDir, qkStr)
 
-                        tileFileName = "%s/%s.jpg" % (tileCacheDir, qkStr)
+                            if ( os.path.exists(tileFileName) ) :                            
+                                # already downloaded
+                                ok = 1; 
+                            else :
+                                print("T",end='')
+                                url = tileUrlTemplate.replace("{subdomain}",imageDomains[0])
+                                url = url.replace("{quadkey}",qkStr)
+                                url = "%s&key=%s" % (url,secrets.bingKey)
 
-                        if ( os.path.exists(tileFileName) ) :                            
-                            # already downloaded
-                            ok = 1; 
-                        else :
-                            print("T",end='')
-                            url = tileUrlTemplate.replace("{subdomain}",imageDomains[0])
-                            url = url.replace("{quadkey}",qkStr)
-                            url = "%s&key=%s" % (url,secrets.bingKey)
+                                response = requests.get(url,stream=True)
+                                
+                                with open(tileFileName,'wb') as out_file:
+                                    shutil.copyfileobj(response.raw, out_file)
 
-                            response = requests.get(url,stream=True)
-                            
-                            with open(tileFileName,'wb') as out_file:
-                                shutil.copyfileobj(response.raw, out_file)
-
-                            del response
-                            neededTile = True
-                    
-            print("")
+                                del response
+                                neededTile = True
+                        
+                print("")
             
             if ( neededTile ):
                 sleep(random()*3)
-
-


### PR DESCRIPTION
While trying to run `python gettilesfrombing.py` , it returns with the following error: 

```
osm/soccer/250124836.GeoJSON Traceback (most recent call last):
  File "gettilesfrombing.py", line 44, in <module>
    tilePixel = quadkey.TileSystem.geo_to_pixel((float(row[0]),float(row[1])), cfg.tileZoom)
ValueError: could not convert string to float: '{"type": "FeatureCollection", "features": [{"geometry": {"coordinates": [[[-71.0508224, 42.3263835], [-71.0508827, 42.3258583], [-71.0496463, 42.3257808], [-71.049586, 42.326306], [-71.0508224, 42.3263835]]], "type": "Polygon"}, "properties": {"wayOSMId": 250124836, "sport": "soccer", "leisure": "pitch"}, "type": "Feature"}]}'
```

Because the code tries to read the csv hence assuming the `osm` dir only contains the `.csv` file, but `GEOJson` file too are in the directory, and when the loop stumbles on the `GEOJson` the above error throws. What I simply did is that I checked the fileformat type and only proceeded the loop, if it's fileformat is `.csv` . And it downloads the tiles accordingly without an error. 